### PR TITLE
Updated driver.js to handle new controllableName

### DIFF
--- a/drivers/io_vertical_exterior_blind/driver.js
+++ b/drivers/io_vertical_exterior_blind/driver.js
@@ -9,7 +9,8 @@ const Driver = require('../Driver');
 class VerticalExteriorBlindDriver extends Driver {
 
   onInit() {
-    this.deviceType = ['io:VerticalExteriorAwningIOComponent'];
+    this.deviceType = ['io:VerticalExteriorAwningIOComponent',
+      'io:AwningValanceIOComponent'];
   }
 
 }


### PR DESCRIPTION
Newer Somfy exterior blinds are now labeled "AwningValanceIOComponent" instead of "VerticalExteriorAwningIOComponent".

Example of device naming from https://www.tahomalink.com/enduser-mobile-web/enduserAPI/setup:

"creationTime": 1571249357000,
            "lastUpdateTime": 1571249357000,
            "label": "Stue 2",
            "deviceURL": "io://xxxx-yyyy-zzzz/zzzzz",
            "shortcut": false,
            "controllableName": "io:AwningValanceIOComponent",
            "definition": {

According to another git they should behave the same way: https://github.com/home-assistant/home-assistant/issues/24673