### PR TITLE
Fixed state and action used by the horizontal awning device

### DIFF
--- a/drivers/WindowCoveringsDevice.js
+++ b/drivers/WindowCoveringsDevice.js
@@ -22,6 +22,9 @@ class WindowCoveringsDevice extends Device {
       closed: 'down'
     };
 
+    this.closureActionName = 'setClosure';
+    this.closureStateName = 'core:ClosureState';
+
     this.registerCapabilityListener('windowcoverings_state', this.onCapabilityWindowcoveringsState.bind(this));
     this.registerCapabilityListener('windowcoverings_set', this.onCapabilityWindowcoveringsSet.bind(this));
     super.onInit();
@@ -66,7 +69,7 @@ class WindowCoveringsDevice extends Device {
     const deviceData = this.getData();
     if (!opts.fromCloudSync) {
       const action = {
-        name: 'setClosure',
+        name: this.closureActionName,
         parameters: [Math.round((1-value)*100)]
       };
       Tahoma.executeDeviceAction(deviceData.label, deviceData.deviceURL, action)
@@ -93,7 +96,7 @@ class WindowCoveringsDevice extends Device {
     if (device) {
       //device exists -> let's sync the state of the device
       const states = device.states
-        .filter(state => state.name === 'core:OpenClosedState' || state.name === 'core:ClosureState')
+        .filter(state => state.name === 'core:OpenClosedState' || state.name === this.closureStateName)
         .map(state => {
           const value = this.windowcoveringsStatesMap[state.value] ? this.windowcoveringsStatesMap[state.value]: state.value;
           return {

--- a/drivers/io_horizontal_awning/device.js
+++ b/drivers/io_horizontal_awning/device.js
@@ -21,6 +21,9 @@ class HorizontalAwningDevice extends WindowCoveringsDevice {
       open: 'down',
       closed: 'up'
     };
+
+    this.closureActionName = 'setPosition';
+    this.closureStateName = 'core:DeploymentState';
   }
 }
 


### PR DESCRIPTION
In my installation, the horizontal awning device didn't work properly; its state was not read by the sync function and the command for setting the position (`setClosure`) seemed to be inverted. Through experimentation I've found a combination of state and action names that works for me.

What I'm a bit unsure of is whether or not this has to do with the physical device, so that maybe other users _have_ functioning horizontal awnings (which could perhaps break if this change was applied). Tricky to tell. I only know that the device has never worked for me, and with the proposed changes it does work.

This fixes #87 